### PR TITLE
Added the ability to bypass verification of API SSL Certs.

### DIFF
--- a/src/Aloha/Twilio/Twilio.php
+++ b/src/Aloha/Twilio/Twilio.php
@@ -46,6 +46,27 @@ class Twilio {
 
     private function getTwilio()
     {
+        if (array_key_exists('ssl_verify', $this->config) 
+            && false === $this->config['ssl_verify']) {
+
+            $http = new \Services_Twilio_TinyHttp(
+                'https://api.twilio.com',
+                array('curlopts' => 
+                    array(
+                        CURLOPT_SSL_VERIFYPEER => false,
+                        CURLOPT_SSL_VERIFYHOST => 2,
+                    )
+                )
+            );
+
+            return new \Services_Twilio(
+                $this->config['sid'], 
+                $this->config['token'], 
+                null, 
+                $http
+            );
+        }
+
         return new \Services_Twilio($this->config['sid'], $this->config['token']);
     }
 

--- a/src/config/twilio.php
+++ b/src/config/twilio.php
@@ -33,6 +33,18 @@ return array(
     |
     */
 
-    'from' => ''
+    'from' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Verify Twilios SSL Certificates
+    |--------------------------------------------------------------------------
+    |
+    | Allows the client to bypass verifiying Twilios SSL certificates.
+    | It is STRONGLY advised to leave this set to true for production environments.
+    |
+    */
+
+    'ssl_verify' => true
 
 );


### PR DESCRIPTION
I've encountered problems verifying Twilios API SSL certificates on OS X Yosemite. Haven't got the time to dig around and either replace / upgrade CURL or find another solution as the package is working fine on testing & production Linux based systems. This pull request adds the ability disable verifying their API SSL certificates via the config file, handy for development.